### PR TITLE
Add additional context to needed to add an identity before using NetworkingMessages

### DIFF
--- a/docs/classes/networking_messages.md
+++ b/docs/classes/networking_messages.md
@@ -2,6 +2,8 @@
 
 Networking API intended to make it easy to port non-connection-oriented code to take advantage of P2P connectivity and [Steam Datagram Relay](https://partner.steamgames.com/doc/features/multiplayer/steamdatagramrelay){ target="\_blank" }. These are part of the newer networking classes; not to be confused with the [older, now-deprecated Networking class](networking.md).
 
+You must call [addIdentity](networking_types.md#addidentity) or [addIpAddress](networking_types.md#addipaddress) prior to making any calls that use identity_reference.
+
 !!! info "Only available in the main [GodotSteam branches](https://github.com/GodotSteam/GodotSteam){ target="\_blank" } and [GodotSteam Server branches](https://github.com/GodotSteam/GodotSteam-Server){ target="\_blank" }"
 
 {==

--- a/docs/classes/networking_types.md
+++ b/docs/classes/networking_types.md
@@ -4,6 +4,8 @@ Miscellaneous types and functions used by networking APIs. These are part of the
 
 These Networking Type functions are all unique to GodotSteam since we cannot work with C++ structs directly in GDscript. These will create networking identities to use with [Networking Messages](networking_messages.md), [Networking Sockets](networking_sockets.md), and [Networking Utils](networking_utils.md) classes. Much like how it works in a C++ implementation, the struct must be created (with either [addIdentity](#addidentity) or [addIPAddress](#addipaddress)) then it must be populated with data (Steam ID, IP address, etc.).
 
+For more information on using Networking Types for [Networking Messages](networking_messages.md), look over the _on_network_messages_session_request function in the [Networking Tutorial](https://github.com/GodotSteam/GodotSteam-Example-Project/blob/godot3/example/src/networking.gd) to understand the flow of addIdentity, setIdentitySteamID64, & acceptSessionWithUser before you call your Networking Messages functions.
+
 !!! info "Only available in the main [GodotSteam branches](https://github.com/GodotSteam/GodotSteam){ target="\_blank" } and [GodotSteam Server branches](https://github.com/GodotSteam/GodotSteam-Server){ target="\_blank" }"
 
 {==


### PR DESCRIPTION
I ran into a brick wall while setting up NetworkingMessages because I had no idea that I needed to set an Identity from the NetworkingTypes class that isn't referenced in the NetworkingMessages class. So I added some documentation in NetworkingTypes & NetworkingMessages to let others know they need to add an identity first. I also linked to the Godot3 example, which should probably be updated to use `setIdentitySteamID64` instead of `setIdentitySteamID ` as talked about [here](https://discord.com/channels/564589037411893260/770388987944501328/1214970518545891469).