### PR TITLE
Update `exporting_shipping.md` to include links to the templates

### DIFF
--- a/docs/tutorials/exporting_shipping.md
+++ b/docs/tutorials/exporting_shipping.md
@@ -2,7 +2,7 @@
 
 This topic comes up a lot and _also_ trips folks up a lot; so this tutorial is here to help.
 
-Exporting and shipping your game with GodotSteam is pretty easy once you get the flow down. This tutorial assumes you are downloading pre-compiled versions of the GodotSteam templates instead of compiling them; however, it will obviously work the same with the ones you compile yourself.
+Exporting and shipping your game with GodotSteam is pretty easy once you get the flow down. This tutorial assumes you are downloading [pre-compiled versions of the GodotSteam templates](https://github.com/GodotSteam/GodotSteam/releases) instead of compiling them; however, it will obviously work the same with the ones you compile yourself.
 
 {==
 ## Exporting for Modules / Pre-Compiles


### PR DESCRIPTION
There should be a link to the templates referenced throughout the article.

Since the `releases/latest` url points to the (currently) `v4.6gde` and that may not be the one the average reader is looking for, I opted for linking directly to the releases page. At least it points the reader into the right direction as to where to get the template files.

This PR closes #10 