### PR TITLE
Git URLs and Typos

### DIFF
--- a/docs/classes/music.md
+++ b/docs/classes/music.md
@@ -108,7 +108,7 @@ These callbacks require you to run ```Steam.run_callbacks()``` in your ```_proce
 ### music_playback_status_has_changed
 
 !!! function "music_playback_status_has_changed"
-	No notes about this in the Steam docs, but we can assume it just updates us about the plaback status.
+	No notes about this in the Steam docs, but we can assume it just updates us about the playback status.
 
 	**Returns:** nothing
 

--- a/docs/howto/gdextension.md
+++ b/docs/howto/gdextension.md
@@ -50,7 +50,7 @@ Alternatively, you can [download the GDExtension source from our repository](htt
 If you changed your target version or manually downloaded the GDExtension source, you can head into the ***godotsteam_gdextension*** folder and clone the latest Godot CPP source in a folder called ***godot-cpp*** like so:
 
 ```shell
-git clone git@github.com:godotengine/godot-cpp.git -b 4.1 godot-cpp
+git clone https://github.com/godotengine/godot-cpp.git -b 4.1 godot-cpp
 ```
 
 You may need to change the given tag(s) above from whatever it is to whatever the current version or whatever version you need.

--- a/docs/howto/gdnative.md
+++ b/docs/howto/gdnative.md
@@ -50,7 +50,7 @@ Alternatively, you can [download the GDNative source from our repository](https:
 If you changed your target version or manually downloaded the GDNative source, you can head into the ***godotsteam_gdnative*** folder and clone the latest Godot CPP source in a folder called ***godot-cpp*** like so:
 
 ```shell
-git clone https://github.com/godotengine/godot.git -b godot-3.5.1-stable godot-cpp
+git clone https://github.com/godotengine/godot-cpp.git -b godot-3.5.1-stable godot-cpp
 ```
 
 You may need to change the given tag(s) above from whatever it is to whatever the current version or whatever version you need.
@@ -281,7 +281,7 @@ In a text editor, create a file called ***steam.gd*** and place the following in
 ```gdscript
 extends Node
 
-onready var Steam: Object = preload("res://addons/godotsteam/godotsteam.gdns").new()
+@onready var Steam: Object = preload("res://addons/godotsteam/godotsteam.gdns").new()
 var steam_app_id: int = 480   # or your game's app ID
 
 

--- a/docs/howto/gdnative.md
+++ b/docs/howto/gdnative.md
@@ -281,7 +281,7 @@ In a text editor, create a file called ***steam.gd*** and place the following in
 ```gdscript
 extends Node
 
-@onready var Steam: Object = preload("res://addons/godotsteam/godotsteam.gdns").new()
+onready var Steam: Object = preload("res://addons/godotsteam/godotsteam.gdns").new()
 var steam_app_id: int = 480   # or your game's app ID
 
 


### PR DESCRIPTION
- Reverted git clone in GDExtension URL to HTTPS for uniformity 

_(When you use SSH to clone a repository, it authenticates using SSH keys without needing your GitHub username and password. In contrast, HTTPS cloning prompts for your GitHub credentials directly, making it more straightforward if you haven't set up SSH keys.)_

- Fixed git clone URL in GDNative to clone from godot-cpp.git
- Typo In Music, Typo in GNative