### PR TITLE
Name change for reading p2p packets

### DIFF
--- a/docs/tutorials/p2p.md
+++ b/docs/tutorials/p2p.md
@@ -314,7 +314,7 @@ To accomplish this, we add a single line of code to our `read_p2p_packet` functi
 				print("WARNING: read an empty packet with non-zero size!")
 
 			# Get the remote user's ID
-			var packet_sender: int = this_packet['steam_id_remote']
+			var packet_sender: int = this_packet['remote_steam_id']
 
 			# Make the packet data readable
 			var packet_code: PoolByteArray = this_packet['data']
@@ -342,7 +342,7 @@ To accomplish this, we add a single line of code to our `read_p2p_packet` functi
 				print("WARNING: read an empty packet with non-zero size!")
 
 			# Get the remote user's ID
-			var packet_sender: int = this_packet['steam_id_remote']
+			var packet_sender: int = this_packet['remote_steam_id']
 
 			# Make the packet data readable
 			var packet_code: PackedByteArray = this_packet['data']

--- a/docs/tutorials/p2p.md
+++ b/docs/tutorials/p2p.md
@@ -122,7 +122,7 @@ Inside that handshake there was a call to the `read_p2p_packet()` function which
 				print("WARNING: read an empty packet with non-zero size!")
 
 			# Get the remote user's ID
-			var packet_sender: int = this_packet['steam_id_remote']
+			var packet_sender: int = this_packet['remote_steam_id']
 
 			# Make the packet data readable
 			var packet_code: PoolByteArray = this_packet['data']
@@ -148,7 +148,7 @@ Inside that handshake there was a call to the `read_p2p_packet()` function which
 				print("WARNING: read an empty packet with non-zero size!")
 
 			# Get the remote user's ID
-			var packet_sender: int = this_packet['steam_id_remote']
+			var packet_sender: int = this_packet['remote_steam_id']
 
 			# Make the packet data readable
 			var packet_code: PackedByteArray = this_packet['data']


### PR DESCRIPTION
Ran into an error trying to read p2p packets in Godot 4.2.2, seems like a name has changed from "steam_id_remote" to "remote_steam_id"