### PR TITLE
Fixed example of Rich Presence config file to be valid VDF

### DIFF
--- a/docs/tutorials/rich_presence.md
+++ b/docs/tutorials/rich_presence.md
@@ -12,18 +12,15 @@ This short tutorial is all about rich presence for your game; specifically the g
 ## Setting It Up
 ==}
 
-First you will need to set up your localization file in the Steamworks back-end. Obviously without this step the rich presence text does not really work as it has nothing to reference. You will need to set up your text file like this:
+First you will need to set up your localization file in the Steamworks back-end. Obviously without this step the rich presence text does not really work as it has nothing to reference. You will need to set up your text file like this and save it as `.vdf` file:
 
 ```gdscript
 "lang" {
-	"language" {
-		"english" {
-			"tokens" {
-				"#something1"	"Rich presence string"
-				"#something2"	"Another string"
-				"#something_with_input"	"{something: %input%"
-			}
-		}
+	"Language" "english"
+	"Tokens" {
+		"#something1"   "Rich presence string"
+		"#something2"   "Another string"
+		"#something_with_input"	"{#something%something_number%}: %score%"
 	}
 }
 ```


### PR DESCRIPTION
The current example in the docs isn't a valid localization file and was rejected by Steamworks with not very informative error message: "Unknown/unsupported language 'language' in file."

I've changed the example to be a valid localization VDF format.
I've also added the suggestion to save the file as `.vdf` since the upload form expects this extension — I've managed to upload any file from macOS just by dragging it into the upload dialog, but I'm not sure if that's the case for another operating systems.

Another (probably better) alternative would be to just re-use the entire code snippet from official Steamworks documentation, as it more clearly shows token referencing from other tokens (but I'm not sure whether that's an NDA violation :D)