### PR TITLE
Fix invalid tab title

### DIFF
--- a/docs/tutorials/initializing.md
+++ b/docs/tutorials/initializing.md
@@ -194,7 +194,7 @@ Some users have noticed that if their `run_callbacks` sits in a script or node t
 
 Putting it together should give us something like this:
 
-=== "Without internal app ID and callbacks"
+=== "With internal app ID and callbacks"
 
 	```gdscript
 	extends Node
@@ -243,7 +243,7 @@ Putting it together should give us something like this:
 			get_tree().quit()
 	```
 
-=== "With internal app ID and callbacks"
+=== "Without internal app ID and callbacks"
 
 	```gdscript
 	extends Node


### PR DESCRIPTION
As far as I can see the tab titles are accidentally swapped around, this pr fixes this.