### PR TITLE
Fix docs for 'receiveMessagesOnChannel'

### DIFF
--- a/docs/classes/networking_messages.md
+++ b/docs/classes/networking_messages.md
@@ -112,7 +112,7 @@ Networking API intended to make it easy to port non-connection-oriented code to 
 
 	Contains the following keys:
 
-	* payload (string)
+	* payload (PackedByteArray)
 	* size (int)
 	* connection (uint32)
 	* identity (uint64_t)


### PR DESCRIPTION
Same issue as previously found in-editor docs; description for dictionary returned by 'receiveMessagesOnChannel' shows 'payload (string)' when it should show 'payload (PackedByteArray)'. 