### PR TITLE
Removed requestCurrentStats references

### DIFF
--- a/docs/classes/user_stats.md
+++ b/docs/classes/user_stats.md
@@ -41,8 +41,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 
 	This is primarily only ever used for testing.
 	
-	You must have called [requestCurrentStats](#requestcurrentstats) and it needs to return successfully via its callback prior to calling this.
-
 	This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock status to the server and to trigger the Steam overlay notification you must call [storeStats](#storestats).
 
 	**Returns:** bool
@@ -430,8 +428,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 !!! function "getStatFloat( ```string``` name )"
 	Gets the current value of the a stat for the current user.
 
-	You must have called [requestCurrentStats](#requestcurrentstats) and it needs to return successfully via its callback prior to calling this.
-
 	To receive stats for other users use [getUserStatFloat](#getuserstatfloat).
 
 	**Returns:** float
@@ -443,8 +439,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 
 !!! function "getStatInt( ```string``` name )"
 	Gets the current value of the a stat for the current user.
-
-	You must have called [requestCurrentStats](#requestcurrentstats) and it needs to return successfully via its callback prior to calling this.
 
 	To receive stats for other users use [getUserStatInt](#getuserstatint).
 
@@ -538,28 +532,10 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
     ---
     [:fontawesome-brands-steam: Read more in the official Steamworks SDK documentation](https://partner.steamgames.com/doc/api/ISteamUserStats#IndicateAchievementProgress){ .md-button .md-button--store target="_blank" }
 
-### requestCurrentStats
-
-!!! function "requestCurrentStats()"
-	Asynchronously request the user's current stats and achievements from the server.
-
-	You must always call this first to get the initial status of stats and achievements. Only after the resulting callback comes back can you start calling the rest of the stats and achievement functions for the current user.
-
-	The equivalent function for other users is [requestUserStats](#requestuserstats).
-
-	Triggers a [current_stats_received](#current_stats_received) callback.
-
-	**Returns:** bool
-
-    ---
-    [:fontawesome-brands-steam: Read more in the official Steamworks SDK documentation](https://partner.steamgames.com/doc/api/ISteamUserStats#RequestCurrentStats){ .md-button .md-button--store target="_blank" }
-
 ### requestGlobalAchievementPercentages
 
 !!! function "requestGlobalAchievementPercentages()"
 	Asynchronously fetches global stats data, which is available for stats marked as "aggregated" in the App Admin panel of the Steamworks website.
-
-	You must have called [requestCurrentStats](#requestcurrentstats) and it needs to return successfully via its callback prior to calling this.
 
 	Triggers a [global_achievement_percentages_ready](#global_achievement_percentages_ready) callback.
 
@@ -574,8 +550,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 	Asynchronously fetches global stats data, which is available for stats marked as "aggregated" in the App Admin panel of the Steamworks website.
 
 	The limit is 60.
-
-	You must have called [requestCurrentStats](#requestcurrentstats) and it needs to return successfully via its callback prior to calling this.
 
 	Triggers a [global_stats_received](#global_stats_received) callback.
 
@@ -592,8 +566,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 	These stats are not automatically updated; you'll need to call this function again to refresh any data that may have change.
 	To keep from using too much memory, an least recently used cache (LRU) is maintained and other user's stats will occasionally be unloaded. When this happens a [user_stats_unloaded](#user_stats_unloaded) callback is sent. After receiving this callback the user's stats will be unavailable until this function is called again.
 
-	The equivalent function for the local user is [requestCurrentStats](#requestcurrentstats).
-
 	Triggers a [user_stats_received](#user_stats_received) callback.
 
 	**Returns:** void
@@ -606,7 +578,7 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 !!! function "resetAllStats( ```bool``` achievements_too )"
 	Resets the current users stats and, optionally achievements.
 
-	This automatically calls [storeStats](#storestats) to persist the changes to the server. This should typically only be used for testing purposes during development. Ensure that you sync up your stats with the new default values provided by Steam after calling this by calling [requestCurrentStats](#requestcurrentstats).
+	This automatically calls [storeStats](#storestats) to persist the changes to the server. This should typically only be used for testing purposes during development.
 
 	**Returns:** bool
 
@@ -617,8 +589,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 
 !!! function "setAchievement( ```string``` name )"
 	Unlocks an achievement.
-
-	You must have called [requestCurrentStats](#requestcurrentstats) and it needs to return successfully via its callback prior to calling this!
 
 	You can unlock an achievement multiple times so you don't need to worry about only setting achievements that aren't already set. This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock status to the server and to trigger the Steam overlay notification you must call [storeStats](#storestats).
 
@@ -643,8 +613,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 !!! function "setStatFloat( ```string``` name, ```float``` value )"
 	Sets / updates the float value of a given stat for the current user.
 
-	You must have called [requestCurrentStats](#requestcurrentstats) and it needs to return successfully via its callback prior to calling this!
-
 	This call only modifies Steam's in-memory state and is very cheap. Doing so allows Steam to persist the changes even in the event of a game crash or unexpected shutdown. To submit the stats to the server you must call [storeStats](#storestats).
 
 	If this is returning false and everything appears correct, then check to ensure that your changes in the App Admin panel of the Steamworks website are published.
@@ -658,8 +626,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 
 !!! function "setStatInt( ```string``` name, ```int32``` value )"
 	Sets / updates the integer value of a given stat for the current user.
-
-	You must have called [requestCurrentStats](#requestcurrentstats) and it needs to return successfully via its callback prior to calling this!
 
 	This call only modifies Steam's in-memory state and is very cheap. Doing so allows Steam to persist the changes even in the event of a game crash or unexpected shutdown. To submit the stats to the server you must call [storeStats](#storestats).
 
@@ -697,8 +663,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 !!! function "updateAvgRateStat( ```string``` name, ```float``` this_session, ```double``` session_length )"
 	Updates an AVGRATE stat with new values.
 
-	You must have called [requestCurrentStats](#requestcurrentstats) and it needs to return successfully via its callback prior to calling this!
-
 	This call only modifies Steam's in-memory state and is very cheap. Doing so allows Steam to persist the changes even in the event of a game crash or unexpected shutdown. To submit the stats to the server you must call [storeStats](#storestats).
 
 	If this is returning false and everything appears correct, then check to ensure that your changes in the App Admin panel of the Steamworks website are published.
@@ -731,20 +695,6 @@ Provides functions for accessing and submitting stats, achievements, and leaderb
 ==}
 
 These callbacks require you to run ```Steam.run_callbacks()``` in your ```_process()``` function to receive them.
-
-### current_stats_received
-
-!!! function "current_stats_received"
-	Called when the latest stats and achievements for the local user have been received from the server; in response to function [requestCurrentStats](#requestcurrentstats).
-
-	**Returns:**
-
-	* game (uint64_t)
-	* result (uint32_t)
-	* user (uint64_t) as Steam ID
-
-	---
-	[:fontawesome-brands-steam: Read more in the official Steamworks SDK documentation](https://partner.steamgames.com/doc/api/ISteamUserStats#UserStatsReceived_t){ .md-button .md-button--store target="_blank" }
 
 ### global_achievement_percentages_ready
 

--- a/docs/issues/common_issues.md
+++ b/docs/issues/common_issues.md
@@ -16,7 +16,7 @@ What could possibly go wrong? Well, we will cover some of those common pitfalls 
 
 Sometimes your brand new achievements don't seem to be triggering. One cause can be that you didn't publish them in the Steamworks back-end. Once they are added into Steam's system, you'll need to publish the changes to be able to work with them.
 
-Some users have also found that getting or setting achievements doesn't work at all until the player's current stats have been retrieved. GodotSteam should do this by default when you initialize Steamworks; unless, that is, you passed `false` to either `steamInit()` or `steamInitEx()`.  If so, just call `requestCurrentStats()` or `requestUserStats()`.
+Some users have also found that getting or setting achievements doesn't work at all until the player's current stats have been retrieved. GodotSteam should do this by default when you initialize Steamworks; unless, that is, you passed `false` to either `steamInit()` or `steamInitEx()`.  If so, just call `requestUserStats()`.
 
 ### Leaderboard Names
 

--- a/docs/tutorials/achievement_icons.md
+++ b/docs/tutorials/achievement_icons.md
@@ -14,7 +14,6 @@ This quick tutorial will cover to how get achievement icons from Steam's servers
 ??? guide "Relevant GodotSteam classes and functions"
 	* [User Stats class](../classes/user_stats.md)
 		* [getAchievementIcon()](../classes/user_stats.md#getachievementicon)
-		* [requestCurrentStats()](../classes/user_stats.md#requestcurrentstats)
 	* [Utils class](../classes/utils.md)
 		* [getImageRGBA()](../classes/utils.md#getimagergba)
 		* [getImageSize()](../classes/utils.md#getimagesize)

--- a/docs/tutorials/stats_achievements.md
+++ b/docs/tutorials/stats_achievements.md
@@ -13,7 +13,6 @@ At some point you may want to save statistics to Steam's database and / or use t
 
 ??? guide "Relevant GodotSteam classes and functions"
 	* [User Stats class](../classes/user_stats.md)
-		* [requestCurrentStats()](../classes/user_stats.md#requestcurrentstats)
 		* [getAchievement()](../classes/user_stats.md#getachievement)
 		* [setAchievement()](../classes/user_stats.md#setachievement)
 		* [setStatFloat()](../classes/user_stats.md#setstatfloat)


### PR DESCRIPTION
After some confusing moments I figured that requestCurrentStats was removed. It is still referenced all over the docs though. 

More changes than just removing the references might be required, I'm sadly not familiar enough with the codebase to judge that.